### PR TITLE
How to Create an Image placeholder in a Pomodoro Break issue #46

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -706,7 +706,7 @@ with an appropriate `alt` text for accessibility.
 + `<p>` we use a paragraph to inform/remind the product owner
 what the ideal dimensions are for the image they should upload.
   + `fw1` - "font weight 1", used to "fade" the font on the instructions.
-  + `fw5` -
+  + `fw5` - "font weight 5", make the pixel dimensions more prominent.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ in **much less time**._
   - [Typography](#typography)
   - [Layout](#layout)
   - [Theming](#theming)
++ [Image Placeholder Example](#how-to-create-an-image-placeholder)
 - [Resources](#resources)
   - [Articles](#articles)
   - [Questions and Discussions](#questions-and-discussions)
@@ -603,7 +604,7 @@ Widths are denoted by the `w` class, followed by one of 3 types of _modifiers_:
 Heights are denoted by the `h` class, followed by one of 3 types of _modifiers_:
 + _Numbers scale_ which follows tachyons' powers of two scale mentioned above
   + Starting at `h1` (1rem) to `h5`(16rem)
-  + e.g. `h1` sets the height of the element to the first step in the 
+  + e.g. `h1` sets the height of the element to the first step in the
   height scale (1rem) whereas `h4` sets the height to the fourth step (8rem)
 + _Percentage literals_
   + Starting at `h-25` for `25%` and going up in 25s (e.g. `h-50`, etc) until `h-100`
@@ -659,6 +660,53 @@ Opacity mostly follows a linear pattern `o-` with a number decrementing in multi
 
 In addition, tachyons offers: `o-05`, `o-025` and `o-0`.
 
+## How To Create an Image Placeholder
+
+Often in projects that feature images,
+we want to display a _placeholder_ when no image is availale.
+For example in an e-commerce product, we don't want to have a "blank" `<div>`
+because it's unfriendly to users.
+
+We can _easily_ solve this issue with a bit of HTML and Tachyons:
+```html
+<div class="center bg-light-gray ba b--gray tc"
+  style="width: 800px; height: 300px;">
+  <img class="center pt5"/
+  alt="Placeholder Image - Please upload an appropriate one."
+  src="https://user-images.githubusercontent.com/194400/49571717-f392d480-f931-11e8-96f2-a8d10cfe375e.png">
+  <p class="fw1">This is a placeholder image. <br />
+    Please upload a more relevant one. Ideal dimensions:<br />
+    <b class="fw5">Width: 800 pixels, Height: 300 pixels.</b>
+  </p>
+</div>
+```
+The effect is:
+![image placeholder example](https://user-images.githubusercontent.com/194400/49573332-a57fd000-f935-11e8-9188-7f5a038a18b5.png)
+
+Complete file for this example in:
+[`image-placeholder.html`](https://github.com/dwyl/learn-tachyons/blob/master/image-placeholder.html)
+
+### Break it down:
+
+Let's break down this HTML and the Tachyons classes we have used:
+
++ A `<div>` which we use to "contain" (or "wrap") the image
+and apply the grey background color:
+  + `center` -  _center_ the `<div>` in the page,
+  you can chose your own positioning to suit your needs.
+  + `bg-light-gray` - literally background light gray.
+  + `ba` - border "all" (_all sides of the div_)
+  + `b--gray` - the color of the border, in this case `gray`.
+  + `tc` - "text centre", these abreviations take a bit of learning,
+  but once you know them they make perfect sense.
++ `<img>` a tiny placeholder image
+with an appropriate `alt` text for accessibility.
+  + `center` - same again, to center the image in the container `<div>`
+  + `pt5` - "padding top 5", this is just to add some space.
++ `<p>` we use a paragraph to inform/remind the product owner
+what the ideal dimensions are for the image they should upload.
+  + `fw1` - "font weight 1", used to "fade" the font on the instructions.
+  + `fw5` -
 
 ## Resources
 

--- a/image-placeholder.html
+++ b/image-placeholder.html
@@ -13,10 +13,10 @@
 
     <div class="center bg-light-gray ba b--gray tc"
       style="width: 800px; height: 300px;">
-      <img class="center v-mid pt5"/
+      <img class="center pt5"/
       alt="Placeholder Image - Please upload an appropriate one."
       src="https://user-images.githubusercontent.com/194400/49571717-f392d480-f931-11e8-96f2-a8d10cfe375e.png">
-      <p class="v-btm fw1">This is a placeholder image. <br />
+      <p class="fw1">This is a placeholder image. <br />
         Please upload a more relevant one. Ideal dimensions:<br />
         <b class="fw5 pt2">Width: 800 pixels, Height: 300 pixels.</b>
       </p>

--- a/image-placeholder.html
+++ b/image-placeholder.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+    <title>Image Placeholder Example</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://unpkg.com/tachyons@4.10.0/css/tachyons.min.css">
+    <link rel="shortcut icon" type="image/png" href="http://www.dwyl.io/img/favicon.ico"/>
+  </head>
+  <body class="debug-grid helvetica">
+    <h1 class="tc"> Image Placeholder </h1>
+
+    <div class="center bg-light-gray ba b--gray tc"
+      style="width: 800px; height: 300px;">
+      <img class="center v-mid pt5"/
+      alt="Placeholder Image - Please upload an appropriate one."
+      src="https://user-images.githubusercontent.com/194400/49571717-f392d480-f931-11e8-96f2-a8d10cfe375e.png">
+      <p class="v-btm fw1">This is a placeholder image. <br />
+        Please upload a more relevant one. Ideal dimensions:<br />
+        <b class="fw5 pt2">Width: 800 pixels, Height: 300 pixels.</b>
+      </p>
+    </div>
+
+    <!-- debug grid is perfect for learning CSS positioning! see: http://tachyons.io/xray/ -->
+    <link rel="stylesheet" href="https://unpkg.com/tachyons-debug-grid@1.2.3/css/tachyons-debug-grid.min.css" />
+  </body>
+</html>


### PR DESCRIPTION
Recently the topic of an Image Placeholder came up in a client project.
There was a _concern_ that the image we were using was the "copyright" of someone `else`.
So I decided to "fix" it and add to our body of collective knowledge.
In my "pomodoro break". 🍅 ⏳ ✅ 

+ [x] Adds instructions and example for creating a versatile/customisable Image Placeholder #46 

![image](https://user-images.githubusercontent.com/194400/49574787-1379c680-f939-11e8-9b41-8bccb0208955.png)
